### PR TITLE
Some fixes and 'allowed groups for bastion group' feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .settings/*
 .classpath
 .project
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>isaac</groupId>
   <artifactId>Bastion</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.0</version>
+  <version>2.2.0</version>
   <name>Bastion</name>
   <url>https://github.com/DevotedMC/Bastion</url>
   

--- a/src/main/java/isaac/bastion/BastionBlock.java
+++ b/src/main/java/isaac/bastion/BastionBlock.java
@@ -133,7 +133,7 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
 		PlayerReinforcement reinforcement = getReinforcement();
 
 		if(reinforcement!=null){
-			return NameAPI.getGroupManager().hasAccess(reinforcement.getGroup(), player.getUniqueId(), PermissionType.getPermission("BASTION_PEARL"));
+			return NameAPI.getGroupManager().hasAccess(reinforcement.getGroup(), player.getUniqueId(), PermissionType.getPermission(Permissions.BASTION_PEARL));
 		}
 		return true;
 	}
@@ -149,7 +149,7 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
 		if (reinforcement == null) return true;
 		if (player == null) return false;
 
-		return NameAPI.getGroupManager().hasAccess(reinforcement.getGroup(), player.getUniqueId(), PermissionType.getPermission("BASTION_PLACE"));
+		return NameAPI.getGroupManager().hasAccess(reinforcement.getGroup(), player.getUniqueId(), PermissionType.getPermission(Permissions.BASTION_PLACE));
 	}
 	
 	/**
@@ -180,7 +180,7 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
 
 		for (UUID player: players){
 			if (player != null)
-				if (NameAPI.getGroupManager().hasAccess(reinforcement.getGroup(), player, PermissionType.getPermission("BASTION_PLACE")))
+				if (NameAPI.getGroupManager().hasAccess(reinforcement.getGroup(), player, PermissionType.getPermission(Permissions.BASTION_PLACE)))
 					return true;
 		}
 

--- a/src/main/java/isaac/bastion/BastionGroup.java
+++ b/src/main/java/isaac/bastion/BastionGroup.java
@@ -1,0 +1,40 @@
+/**
+ * Created by Aleksey on 11.07.2017.
+ */
+
+package isaac.bastion;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class BastionGroup {
+	private int groupId;
+	private Set<Integer> allowedGroupIds;
+
+	public BastionGroup(int groupId) {
+		this.groupId = groupId;
+		this.allowedGroupIds = new HashSet<>();
+	}
+
+	public int getGroupId() {
+		return this.groupId;
+	}
+
+	public void addAllowedGroup(int groupId) {
+		this.allowedGroupIds.add(groupId);
+	}
+
+	public boolean removeAllowedGroup(int groupId) {
+		this.allowedGroupIds.remove(groupId);
+
+		return this.allowedGroupIds.size() > 0;
+	}
+
+	public boolean isAllowedGroup(int groupId) {
+		return this.allowedGroupIds.contains(groupId);
+	}
+
+	public Set<Integer> getAllowedGroupIds() {
+		return this.allowedGroupIds;
+	}
+}

--- a/src/main/java/isaac/bastion/CommonSettings.java
+++ b/src/main/java/isaac/bastion/CommonSettings.java
@@ -1,0 +1,23 @@
+/**
+ * Created by Aleksey on 16.07.2017.
+ */
+
+package isaac.bastion;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+public class CommonSettings {
+	private boolean cancelReinInBastionField;
+
+	public boolean isCancelReinInBastionField() {
+		return this.cancelReinInBastionField;
+	}
+
+	public static CommonSettings load(ConfigurationSection config) {
+		CommonSettings settings = new CommonSettings();
+		settings.cancelReinInBastionField = config.getBoolean("cancelReinInBastionField", false);
+
+		return settings;
+	}
+
+}

--- a/src/main/java/isaac/bastion/CommonSettings.java
+++ b/src/main/java/isaac/bastion/CommonSettings.java
@@ -7,15 +7,15 @@ package isaac.bastion;
 import org.bukkit.configuration.ConfigurationSection;
 
 public class CommonSettings {
-	private boolean cancelReinInBastionField;
+	private boolean cancelReinforcementModeInBastionField;
 
-	public boolean isCancelReinInBastionField() {
-		return this.cancelReinInBastionField;
+	public boolean isCancelReinforcementModeInBastionField() {
+		return this.cancelReinforcementModeInBastionField;
 	}
 
 	public static CommonSettings load(ConfigurationSection config) {
 		CommonSettings settings = new CommonSettings();
-		settings.cancelReinInBastionField = config.getBoolean("cancelReinInBastionField", false);
+		settings.cancelReinforcementModeInBastionField = config.getBoolean("cancelReinforcementModeInBastionField", false);
 
 		return settings;
 	}

--- a/src/main/java/isaac/bastion/Permissions.java
+++ b/src/main/java/isaac/bastion/Permissions.java
@@ -1,0 +1,11 @@
+/**
+ * Created by Aleksey on 11.07.2017.
+ */
+
+package isaac.bastion;
+
+public class Permissions {
+	public static final String BASTION_PEARL = "BASTION_PEARL";
+	public static final String BASTION_PLACE = "BASTION_PLACE";
+	public static final String BASTION_MANAGE_GROUPS = "BASTION_MANAGE_GROUPS";
+}

--- a/src/main/java/isaac/bastion/commands/GroupCommandManager.java
+++ b/src/main/java/isaac/bastion/commands/GroupCommandManager.java
@@ -1,0 +1,44 @@
+/**
+ * Created by Aleksey on 14.07.2017.
+ */
+
+package isaac.bastion.commands;
+
+import isaac.bastion.Bastion;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class GroupCommandManager implements CommandExecutor {
+	public enum CommandType { Add, Delete, List }
+
+	private CommandType type;
+
+	public GroupCommandManager(CommandType type) {
+		this.type = type;
+	}
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (!(sender instanceof Player))  return false;
+
+		Player player = (Player)sender;
+
+		if(this.type == CommandType.Add) {
+			if(args.length != 2) return false;
+			Bastion.getGroupManager().addAllowedGroup(player, args[0], args[1]);
+		} else if(this.type == CommandType.Delete) {
+			if(args.length != 2) return false;
+			Bastion.getGroupManager().deleteAllowedGroup(player, args[0], args[1]);
+		} else if(this.type == CommandType.List) {
+			if(args.length != 1) return false;
+			Bastion.getGroupManager().listAllowedGroups(player, args[0]);
+		} else {
+			return false;
+		}
+
+		return true;
+	}
+
+}

--- a/src/main/java/isaac/bastion/listeners/BastionDamageListener.java
+++ b/src/main/java/isaac/bastion/listeners/BastionDamageListener.java
@@ -50,7 +50,7 @@ public final class BastionDamageListener implements Listener {
 	public void onBlockPlace(BlockPlaceEvent event) {
 		Set<Block> blocks = new CopyOnWriteArraySet<Block>();
 		blocks.add(event.getBlock());
-		Set<BastionBlock> blocking = blockManager.shouldStopBlock(null, blocks,event.getPlayer().getUniqueId());
+		Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(null, blocks,event.getPlayer().getUniqueId());
 		
 		if (blocking.size() != 0 && !groupManager.canPlaceBlock(event.getPlayer(), blocking)){
 			blockManager.erodeFromPlace(event.getPlayer(), blocking);
@@ -64,7 +64,7 @@ public final class BastionDamageListener implements Listener {
 	public void onWaterFlow(BlockFromToEvent  event){
 		Set<Block> blocks = new CopyOnWriteArraySet<Block>();
 		blocks.add(event.getToBlock());
-		Set<BastionBlock> blocking = blockManager.shouldStopBlock(event.getBlock(),blocks, null);
+		Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(event.getBlock(),blocks, null);
 		
 		if(blocking.size() != 0){
 			event.setCancelled(true);
@@ -84,7 +84,7 @@ public final class BastionDamageListener implements Listener {
 			playerName = player.getUniqueId();
 		}
 		
-		Set<BastionBlock> blocking = blockManager.shouldStopBlock(event.getLocation().getBlock(), blocks, playerName);
+		Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(event.getLocation().getBlock(), blocks, playerName);
 		
 		if (blocking.size() != 0) {
 			event.setCancelled(true);
@@ -97,7 +97,7 @@ public final class BastionDamageListener implements Listener {
 		Set<Block> involved = new HashSet<Block>(event.getBlocks());
 		involved.add(piston.getRelative(event.getDirection()));
 		
-		Set<BastionBlock> blocking = blockManager.shouldStopBlock(piston, involved, null);
+		Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(piston, involved, null);
 		
 		if (blocking.size() != 0) {
 			event.setCancelled(true);
@@ -109,7 +109,7 @@ public final class BastionDamageListener implements Listener {
 		Set<Block> blocks = new HashSet<Block>();
 		blocks.add(event.getBlockClicked().getRelative(event.getBlockFace()));
 		
-		Set<BastionBlock> blocking = blockManager.shouldStopBlock(null, blocks, event.getPlayer().getUniqueId());
+		Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(null, blocks, event.getPlayer().getUniqueId());
 		
 		if (blocking.size() != 0) {
 			event.setCancelled(true);
@@ -123,7 +123,7 @@ public final class BastionDamageListener implements Listener {
 		Set<Block> blocks = new HashSet<Block>();
 		blocks.add(event.getBlock().getRelative( ((Dispenser) event.getBlock().getState().getData()).getFacing()));
 		
-		Set<BastionBlock> blocking = blockManager.shouldStopBlock(event.getBlock(), blocks, null);
+		Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(event.getBlock(), blocks, null);
 
 		if(blocking.size() != 0) {
 			event.setCancelled(true);

--- a/src/main/java/isaac/bastion/listeners/BastionInteractListener.java
+++ b/src/main/java/isaac/bastion/listeners/BastionInteractListener.java
@@ -61,7 +61,7 @@ public class BastionInteractListener implements Listener {
 			isBoat == Material.BOAT_JUNGLE || isBoat == Material.BOAT_SPRUCE ) {
 			Set<Block> blocks = new CopyOnWriteArraySet<Block>();
 			blocks.add(event.getClickedBlock());
-			Set<BastionBlock> blocking = blockManager.shouldStopBlock(null, blocks, player.getUniqueId());
+			Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(null, blocks, player.getUniqueId());
 
 			if (blocking.size() > 0) {
 				event.setCancelled(true);
@@ -152,14 +152,14 @@ public class BastionInteractListener implements Listener {
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
 	public void onReinforcement(ReinforcementCreationEvent event) {
-		if(Bastion.getCommonSettings().isCancelReinInBastionField()) {
+		if(Bastion.getCommonSettings().isCancelReinforcementModeInBastionField()) {
 			Set<Block> blocks = new CopyOnWriteArraySet<Block>();
 			blocks.add(event.getBlock());
-			Set<BastionBlock> blocking = blockManager.shouldStopBlock(null, blocks,event.getPlayer().getUniqueId());
+			Set<BastionBlock> blocking = blockManager.shouldStopBlockByBlockingBastion(null, blocks,event.getPlayer().getUniqueId());
 
 			if (blocking.size() != 0 && !groupManager.canPlaceBlock(event.getPlayer(), blocking)){
 				event.setCancelled(true);
-				event.getPlayer().sendMessage(ChatColor.RED + "Bastion prevents this operation");
+				event.getPlayer().sendMessage(ChatColor.RED + "A Bastion prevents you from reinforcing");
 				return;
 			}
 		}

--- a/src/main/java/isaac/bastion/manager/BastionBlockManager.java
+++ b/src/main/java/isaac/bastion/manager/BastionBlockManager.java
@@ -110,9 +110,8 @@ public class BastionBlockManager {
 		
 		return false;
 	}
-	
 
-	/** 
+	/**
 	 * handles all block based events in a general way
 	 * @param origin
 	 * @param result
@@ -124,28 +123,41 @@ public class BastionBlockManager {
 			Player playerB = Bukkit.getPlayer(player);
 			if (playerB != null && playerB.hasPermission("Bastion.bypass")) return new CopyOnWriteArraySet<BastionBlock>();
 		}
-		
-		Set<BastionBlock> preblocking = new HashSet<BastionBlock>();
+
+		Set<BastionBlock> toReturn = new HashSet<BastionBlock>();
 		Set<UUID> accessors = new HashSet<UUID>();
 		if (player != null) {
 			accessors.add(player);
 		}
-		
+
 		if (origin != null) {
 			PlayerReinforcement reinforcement = (PlayerReinforcement) Citadel.getReinforcementManager().
-			getReinforcement(origin);
+					getReinforcement(origin);
 			if (reinforcement instanceof PlayerReinforcement) {
 				accessors.add(reinforcement.getGroup().getOwner());
 			}
-			
+
 			for (BastionBlock bastion: this.getBlockingBastions(origin.getLocation())) {
 				accessors.add(bastion.getOwner());
 			}
 		}
-		
+
 		for(Block block: result) {
-			preblocking.addAll(getBlockingBastions(block.getLocation(),accessors));
+			toReturn.addAll(getBlockingBastions(block.getLocation(),accessors));
 		}
+
+		return toReturn;
+	}
+
+	/** 
+	 * handles all block based events in a general way
+	 * @param origin
+	 * @param result
+	 * @param player
+	 * @return
+	 */
+	public Set<BastionBlock> shouldStopBlockByBlockingBastion(Block origin, Set<Block> result, UUID player) {
+		Set<BastionBlock> preblocking = shouldStopBlock(origin, result, player);
 
 		// Clear non-blocking
 
@@ -287,7 +299,7 @@ public class BastionBlockManager {
 			if (bastion.getType().isOnlyDirectDestruction()) {
 				sb.append(ChatColor.BLUE).append("Bastion ignores blocks");
 			} else {
-				Group allowedGroup = Bastion.getGroupManager().getAllowedGroup(player, bastion, null);
+				Group allowedGroup = Bastion.getGroupManager().findFirstAllowedGroup(player, bastion);
 
 				if(allowedGroup != null) {
 					sb.append(ChatColor.YELLOW).append("A Bastion Block allows you to build using group [" + allowedGroup.getName() + "]");

--- a/src/main/java/isaac/bastion/manager/BastionGroupManager.java
+++ b/src/main/java/isaac/bastion/manager/BastionGroupManager.java
@@ -123,9 +123,7 @@ public class BastionGroupManager {
 		return true;
 	}
 
-	public Group getAllowedGroup(Player player, BastionBlock bastionBlock, PermissionType perm) {
-		GroupManager groupManager = NameAPI.getGroupManager();
-
+	public Group findFirstAllowedGroup(Player player, BastionBlock bastionBlock) {
 		Reinforcement rein = Citadel.getReinforcementManager().getReinforcement(bastionBlock.getLocation());
 		PlayerReinforcement playerRein = rein != null && (rein instanceof PlayerReinforcement) ? (PlayerReinforcement)rein : null;
 
@@ -137,18 +135,17 @@ public class BastionGroupManager {
 			for(int allowedGroupId : bastionGroup.getAllowedGroupIds()) {
 				Group allowedGroup = GroupManager.getGroup(allowedGroupId);
 
-				if(allowedGroup != null && allowedGroup.isValid()) {
-					if(perm != null && groupManager.hasAccess(allowedGroup, player.getUniqueId(), perm)
-						|| perm == null && allowedGroup.isMember(player.getUniqueId())
-						)
-					{
-						return allowedGroup;
-					}
+				if(allowedGroup != null && allowedGroup.isValid()&& allowedGroup.isMember(player.getUniqueId())) {
+					return allowedGroup;
 				}
 			}
 		}
 
 		return null;
+	}
+
+	public boolean isAllowedGroup(Group group, Group allowedGroup) {
+		return this.storage.isAllowedGroup(group, allowedGroup);
 	}
 
 	private Group findGroup(Player player, String groupName) {

--- a/src/main/java/isaac/bastion/manager/BastionGroupManager.java
+++ b/src/main/java/isaac/bastion/manager/BastionGroupManager.java
@@ -1,0 +1,190 @@
+/**
+ * Created by Aleksey on 14.07.2017.
+ */
+
+package isaac.bastion.manager;
+
+import isaac.bastion.BastionBlock;
+import isaac.bastion.BastionGroup;
+import isaac.bastion.Permissions;
+import isaac.bastion.storage.BastionGroupStorage;
+
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.citadel.Citadel;
+import vg.civcraft.mc.citadel.PlayerState;
+import vg.civcraft.mc.citadel.ReinforcementMode;
+import vg.civcraft.mc.citadel.reinforcement.PlayerReinforcement;
+import vg.civcraft.mc.citadel.reinforcement.Reinforcement;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.*;
+
+public class BastionGroupManager {
+	private static class FoundGroups {
+		public Group group;
+		public Group allowedGroup;
+	}
+
+	private BastionGroupStorage storage;
+
+	public BastionGroupManager(BastionGroupStorage storage) {
+		this.storage = storage;
+	}
+
+	public void addAllowedGroup(Player player, String groupName, String allowedGroupName) {
+		FoundGroups groups = findGroups(player, groupName, allowedGroupName);
+
+		if(groups == null) return;
+
+		if(this.storage.addAllowedGroup(groups.group, groups.allowedGroup)) {
+			player.sendMessage(ChatColor.GREEN + "Group [" + allowedGroupName + "] added to bastion group [" + groupName + "]");
+		} else {
+			player.sendMessage(ChatColor.YELLOW + "Group [" + allowedGroupName + "] is already in bastion group [" + groupName + "]");
+		}
+	}
+
+	public void deleteAllowedGroup(Player player, String groupName, String allowedGroupName) {
+		FoundGroups groups = findGroups(player, groupName, allowedGroupName);
+
+		if(groups == null) return;
+
+		if(this.storage.deleteAllowedGroup(groups.group, groups.allowedGroup)) {
+			player.sendMessage(ChatColor.GREEN + "Group [" + allowedGroupName + "] deleted from bastion group [" + groupName + "]");
+		} else {
+			player.sendMessage(ChatColor.YELLOW + "Group [" + allowedGroupName + "] is not in bastion group [" + groupName + "]");
+		}
+	}
+
+	public void listAllowedGroups(Player player, String groupName) {
+		Group group = findGroup(player, groupName);
+
+		if(group == null) return;
+
+		List<BastionGroup> bastionGroups = this.storage.getBastionGroups(group);
+
+		if(bastionGroups.size() == 0) {
+			player.sendMessage(ChatColor.YELLOW + "There are no groups in bastion group [" + groupName + "]");
+			return;
+		}
+
+		Map<String, String> map = new HashMap<>();
+
+		for(BastionGroup bastionGroup : bastionGroups) {
+			for(int allowedGroupId : bastionGroup.getAllowedGroupIds()) {
+				Group allowedGroup = GroupManager.getGroup(allowedGroupId);
+
+				if(allowedGroup != null && allowedGroup.isValid()) {
+					map.put(allowedGroup.getName().toLowerCase(), allowedGroup.getName());
+				}
+			}
+		}
+
+		if(map.size() == 0) {
+			player.sendMessage(ChatColor.YELLOW + "There are no groups in bastion group [" + groupName + "]");
+			return;
+		}
+
+		List<String> result = new ArrayList<>();
+		result.addAll(map.values());
+
+		Collections.sort(result);
+
+		player.sendMessage(ChatColor.GREEN + "Bastion group [" + groupName + "] has following allowed groups:");
+
+		for(String allowedGroupName : result) {
+			player.sendMessage(ChatColor.GREEN + "- " + allowedGroupName);
+		}
+	}
+
+	public boolean canPlaceBlock(Player player, Set<BastionBlock> bastionBlocks) {
+		PlayerState state = PlayerState.get(player);
+		ReinforcementMode placementMode = state.getMode();
+		Group allowedGroup = state.getGroup();
+
+		if(placementMode != ReinforcementMode.REINFORCEMENT && placementMode != ReinforcementMode.REINFORCEMENT_FORTIFICATION
+				|| allowedGroup == null
+				|| !allowedGroup.isValid()
+				)
+		{
+			return false;
+		}
+
+		for(BastionBlock bastionBlock : bastionBlocks) {
+			Reinforcement rein = Citadel.getReinforcementManager().getReinforcement(bastionBlock.getLocation());
+			PlayerReinforcement playerRein = rein != null && (rein instanceof PlayerReinforcement) ? (PlayerReinforcement)rein : null;
+
+			if(playerRein != null && !this.storage.isAllowedGroup(playerRein.getGroup(), allowedGroup)) return false;
+		}
+
+		return true;
+	}
+
+	public Group getAllowedGroup(Player player, BastionBlock bastionBlock, PermissionType perm) {
+		GroupManager groupManager = NameAPI.getGroupManager();
+
+		Reinforcement rein = Citadel.getReinforcementManager().getReinforcement(bastionBlock.getLocation());
+		PlayerReinforcement playerRein = rein != null && (rein instanceof PlayerReinforcement) ? (PlayerReinforcement)rein : null;
+
+		if(playerRein == null) return null;
+
+		List<BastionGroup> bastionGroups = this.storage.getBastionGroups(playerRein.getGroup());
+
+		for(BastionGroup bastionGroup : bastionGroups) {
+			for(int allowedGroupId : bastionGroup.getAllowedGroupIds()) {
+				Group allowedGroup = GroupManager.getGroup(allowedGroupId);
+
+				if(allowedGroup != null && allowedGroup.isValid()) {
+					if(perm != null && groupManager.hasAccess(allowedGroup, player.getUniqueId(), perm)
+						|| perm == null && allowedGroup.isMember(player.getUniqueId())
+						)
+					{
+						return allowedGroup;
+					}
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private Group findGroup(Player player, String groupName) {
+		Group group = GroupManager.getGroup(groupName);
+
+		if(group == null || !group.isValid()) {
+			player.sendMessage(ChatColor.RED + "Group [" + groupName + "] doesn't exist");
+			return null;
+		}
+
+		PermissionType perm = PermissionType.getPermission(Permissions.BASTION_MANAGE_GROUPS);
+
+		if(!NameAPI.getGroupManager().hasAccess(group, player.getUniqueId(), perm)) {
+			player.sendMessage(ChatColor.RED + "You haven't permissions to manage bastion group [" + groupName + "]");
+			return null;
+		}
+
+		return group;
+	}
+
+	private FoundGroups findGroups(Player player, String groupName, String allowedGroupName) {
+		Group group = findGroup(player, groupName);
+
+		if(group == null) return null;
+
+		Group allowedGroup = GroupManager.getGroup(allowedGroupName);
+
+		if(allowedGroup == null || !allowedGroup.isValid()) {
+			player.sendMessage(ChatColor.RED + "Group [" + allowedGroupName + "] doesn't exist");
+			return null;
+		}
+
+		FoundGroups result = new FoundGroups();
+		result.group = group;
+		result.allowedGroup = allowedGroup;
+
+		return result;
+	}
+}

--- a/src/main/java/isaac/bastion/storage/BastionBlockStorage.java
+++ b/src/main/java/isaac/bastion/storage/BastionBlockStorage.java
@@ -65,28 +65,6 @@ public class BastionBlockStorage {
 	}
 	
 	/**
-	 * Registers database migrations
-	 */
-	public void registerMigrations() {
-		db.registerMigration(0, false, 
-				"create table if not exists `bastion_blocks`("
-				+ "bastion_id int(10) unsigned NOT NULL AUTO_INCREMENT,"
-				+ "bastion_type varchar(40) DEFAULT '" + BastionType.getDefaultType() + "',"
-				+ "loc_x int(10),"
-				+ "loc_y int(10),"
-				+ "loc_z int(10),"
-				+ "loc_world varchar(40) NOT NULL,"
-				+ "placed bigint(20) Unsigned,"
-				+ "fraction float(20) Unsigned,"
-				+ "PRIMARY KEY (`bastion_id`));");
-		db.registerMigration(1, false, 
-				"ALTER TABLE bastion_blocks ADD COLUMN IF NOT EXISTS bastion_type VARCHAR(40) DEFAULT '"
-				+ BastionType.getDefaultType() + "';");	
-		db.registerMigration(2, false, 
-				"ALTER TABLE bastion_blocks ADD COLUMN IF NOT EXISTS dead TINYINT(1) DEFAULT 0;");
-	}
-	
-	/**
 	 * Updates all remaining bastions and cancels the update task
 	 */
 	public void close() {

--- a/src/main/java/isaac/bastion/storage/BastionBlockStorage.java
+++ b/src/main/java/isaac/bastion/storage/BastionBlockStorage.java
@@ -13,9 +13,7 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
-import org.bukkit.World;
+import org.bukkit.*;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.entity.Player;
 
@@ -353,7 +351,7 @@ public class BastionBlockStorage {
 					}
 				}
 			} catch (SQLException e) {
-				log.log(Level.SEVERE, "Error loading bastions from database, shutting down", e);
+				log.log(Level.SEVERE, ChatColor.RED + "===== Error loading bastions from database, shutting down =====", e);
 				Bukkit.getServer().getPluginManager().disablePlugin(Bastion.getPlugin());
 			}
 		}

--- a/src/main/java/isaac/bastion/storage/BastionGroupStorage.java
+++ b/src/main/java/isaac/bastion/storage/BastionGroupStorage.java
@@ -13,6 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.scheduler.BukkitRunnable;
 
 import isaac.bastion.Bastion;
@@ -183,7 +184,7 @@ public class BastionGroupStorage {
 			}
 		} catch (SQLException e) {
 			e.printStackTrace();
-			log.log(Level.SEVERE, "Error loading bastion groups from database, shutting down", e);
+			log.log(Level.SEVERE, ChatColor.RED + "===== Error loading bastion groups from database, shutting down =====", e);
 			Bukkit.getServer().getPluginManager().disablePlugin(Bastion.getPlugin());
 		}
 	}

--- a/src/main/java/isaac/bastion/storage/BastionGroupStorage.java
+++ b/src/main/java/isaac/bastion/storage/BastionGroupStorage.java
@@ -1,0 +1,295 @@
+/**
+ * Created by Aleksey on 11.07.2017.
+ */
+
+package isaac.bastion.storage;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitRunnable;
+
+import isaac.bastion.Bastion;
+import isaac.bastion.BastionGroup;
+
+import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.group.Group;
+
+public class BastionGroupStorage {
+	private static class Operation {
+		public int groupId;
+		public int allowedGroupId;
+		public boolean isAdded;
+	}
+
+	private static class BastionGroupAndAllowed {
+		public BastionGroup bastionGroup;
+		public Integer allowedGroupId;
+	}
+
+	private static final int saveDelay = 60 * 20; //once per 1 minute
+
+	private ManagedDatasource db;
+	private Logger log;
+
+	private List<Operation> changed;
+	private Queue<Operation> localChanged = new ArrayDeque<Operation>();
+
+	private Map<Integer, BastionGroup> groups;
+	private int taskId;
+
+	private static final String selectAllGroups = "select * from bastion_groups order by bastion_group_id;";
+	private static final String selectGroup = "select * from bastion_groups where bastion_group_id = ? and allowed_group_id = ?;";
+	private static final String addGroup = "insert into bastion_groups (bastion_group_id, allowed_group_id) values (?, ?);";
+	private static final String deleteGroup = "delete from bastion_groups where bastion_group_id = ? and allowed_group_id = ?;";
+
+	public BastionGroupStorage(ManagedDatasource db, Logger log) {
+		this.changed = new ArrayList<>();
+		this.groups = new HashMap<>();
+		this.db = db;
+		this.log = log;
+
+		this.taskId = new BukkitRunnable(){
+			public void run(){
+				updateChanged();
+			}
+		}.runTaskTimerAsynchronously(Bastion.getPlugin(), saveDelay, saveDelay).getTaskId();
+	}
+
+	/**
+	 * Updates all remaining bastions and cancels the update task
+	 */
+	public void close() {
+		Bukkit.getScheduler().cancelTask(this.taskId);
+		updateChanged();
+	}
+
+	/**
+	 * Data manipulations methods
+	 */
+
+	/**
+	 * Adds bastion group
+	 * @param group Bastion's group
+	 * @param allowedGroup Allowed group
+	 * @return True is group was added, False - if it already exist
+	 */
+	public boolean addAllowedGroup(Group group, Group allowedGroup) {
+		List<BastionGroup> bastionGroups = getBastionGroups(group);
+
+		if(findBastionGroupAndAllowed(bastionGroups, allowedGroup) != null) return false;
+
+		BastionGroup bastionGroup;
+
+		if(bastionGroups.size() > 0) {
+			bastionGroup = bastionGroups.get(0);
+		} else {
+			this.groups.put(group.getGroupId(), bastionGroup = new BastionGroup(group.getGroupId()));
+		}
+
+		bastionGroup.addAllowedGroup(allowedGroup.getGroupId());
+		addChanged(bastionGroup.getGroupId(), allowedGroup.getGroupId(), true);
+
+		return true;
+	}
+
+	/**
+	 * Deletes a bastion group
+	 * @param group The bastion's group
+	 * @param allowedGroup The allowed group name to delete
+	 * @return True is group was deleted, False - if group doesn't exist
+	 */
+	public boolean deleteAllowedGroup(Group group, Group allowedGroup) {
+		boolean isDeleted = false;
+		BastionGroupAndAllowed bastionGroupAndAllowed;
+
+		while((bastionGroupAndAllowed = getBastionGroupByAllowed(group, allowedGroup)) != null) {
+			if (!bastionGroupAndAllowed.bastionGroup.removeAllowedGroup(bastionGroupAndAllowed.allowedGroupId)) {
+				this.groups.remove(bastionGroupAndAllowed.bastionGroup.getGroupId());
+			}
+
+			addChanged(bastionGroupAndAllowed.bastionGroup.getGroupId(), bastionGroupAndAllowed.allowedGroupId, false);
+
+			isDeleted = true;
+		}
+
+		return isDeleted;
+	}
+
+	public boolean isAllowedGroup(Group group, Group allowedGroup) {
+		return getBastionGroupByAllowed(group, allowedGroup) != null;
+	}
+
+	public List<BastionGroup> getBastionGroups(Group group) {
+		List<BastionGroup> bastionGroups = new ArrayList<BastionGroup>();
+
+		for(int groupId : group.getGroupIds()) {
+			BastionGroup bastionGroup = this.groups.get(groupId);
+
+			if(bastionGroup != null) {
+				bastionGroups.add(bastionGroup);
+			}
+		}
+
+		return bastionGroups;
+	}
+
+
+	/**
+	 * Loads all bastion groups from the database
+	 */
+	public void loadGroups() {
+		try (
+			Connection conn = this.db.getConnection();
+			PreparedStatement ps = conn.prepareStatement(selectAllGroups)
+		) {
+			int validCount = 0;
+			int invalidCount = 0;
+			ResultSet result = ps.executeQuery();
+
+			while(result.next()) {
+				int groupId = result.getInt("bastion_group_id");
+				int allowedGroupId = result.getInt("allowed_group_id");
+				Group group = GroupManager.getGroup(groupId);
+				Group allowedGroup = GroupManager.getGroup(allowedGroupId);
+
+				if(group == null || allowedGroup == null) {
+					addChanged(groupId, allowedGroupId, false);
+					invalidCount++;
+				} else {
+					BastionGroup bastionGroup = this.groups.get(groupId);
+
+					if(bastionGroup == null) {
+						this.groups.put(groupId, bastionGroup = new BastionGroup(groupId));
+					}
+
+					bastionGroup.addAllowedGroup(allowedGroupId);
+
+					validCount++;
+				}
+			}
+
+			log.info("Loaded " + this.groups.size() + " bastion groups with " + validCount + " allowed groups.");
+
+			if(invalidCount > 0) {
+				log.info(" Marked to delete " + invalidCount + " records for non-existent groups.");
+			}
+		} catch (SQLException e) {
+			e.printStackTrace();
+			log.log(Level.SEVERE, "Error loading bastion groups from database, shutting down", e);
+			Bukkit.getServer().getPluginManager().disablePlugin(Bastion.getPlugin());
+		}
+	}
+
+	/**
+	 * Scheduled task methods
+	 */
+
+	private void updateChanged() {
+		try {
+			synchronized (this.changed) {
+				if (this.changed.size() != 0) {
+					this.localChanged.addAll(this.changed);
+					this.changed.clear();
+				}
+			}
+
+			this.log.info("'Update bastion groups' task begin, found " + this.localChanged.size() + " operations to proceed");
+
+			int count = 0;
+
+			try {
+				Operation operation;
+
+				while ((operation = this.localChanged.poll()) != null) {
+					update(operation);
+					count++;
+				}
+			} finally {
+				this.log.info("'Update bastion groups' task ended, " + count + " operations proceeded");
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	private void update(Operation operation) {
+		try (Connection conn = db.getConnection()) {
+			if(operation.isAdded) {
+				try (PreparedStatement ps = conn.prepareStatement(selectGroup)) {
+					ps.setInt(1, operation.groupId);
+					ps.setInt(2, operation.allowedGroupId);
+
+					try (ResultSet result = ps.executeQuery()) {
+						boolean hasData = result.next();
+
+						if (hasData) return;
+					} catch (SQLException e2) {
+						e2.printStackTrace();
+						return;
+					}
+				} catch (SQLException e1) {
+					e1.printStackTrace();
+					return;
+				}
+			}
+
+			String sql = operation.isAdded ? addGroup : deleteGroup;
+
+			try (PreparedStatement ps = conn.prepareStatement(sql)) {
+				ps.setInt(1, operation.groupId);
+				ps.setInt(2, operation.allowedGroupId);
+				ps.executeUpdate();
+			} catch (SQLException e1) {
+				e1.printStackTrace();
+			}
+		} catch (SQLException e2) {
+			e2.printStackTrace();
+		}
+	}
+
+	/**
+	 * Helper methods
+	 */
+
+	private void addChanged(int groupId, int allowedGroupId, boolean isAdded) {
+		Operation operation = new Operation();
+		operation.groupId = groupId;
+		operation.allowedGroupId = allowedGroupId;
+		operation.isAdded = isAdded;
+
+		synchronized (this.changed) {
+			this.changed.add(operation);
+		}
+	}
+
+	private BastionGroupAndAllowed getBastionGroupByAllowed(Group group, Group allowedGroup) {
+		List<BastionGroup> bastionGroups = getBastionGroups(group);
+		return bastionGroups.size() > 0 ? findBastionGroupAndAllowed(bastionGroups, allowedGroup) : null;
+	}
+
+	private BastionGroupAndAllowed findBastionGroupAndAllowed(List<BastionGroup> bastionGroups, Group allowedGroup) {
+		List<Integer> allowedGroupIds = allowedGroup.getGroupIds();
+
+		for(BastionGroup bastionGroup : bastionGroups) {
+			for(int allowedGroupId : allowedGroupIds) {
+				if(bastionGroup.isAllowedGroup(allowedGroupId)) {
+					BastionGroupAndAllowed result = new BastionGroupAndAllowed();
+					result.bastionGroup = bastionGroup;
+					result.allowedGroupId = allowedGroupId;
+
+					return result;
+				}
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/main/java/isaac/bastion/storage/Database.java
+++ b/src/main/java/isaac/bastion/storage/Database.java
@@ -1,0 +1,37 @@
+/**
+ * Created by Aleksey on 14.07.2017.
+ */
+
+package isaac.bastion.storage;
+
+import isaac.bastion.BastionType;
+import vg.civcraft.mc.civmodcore.dao.ManagedDatasource;
+
+public class Database {
+	public static void registerMigrations(ManagedDatasource db) {
+		db.registerMigration(0, false,
+				"create table if not exists `bastion_blocks`("
+						+ "bastion_id int(10) unsigned NOT NULL AUTO_INCREMENT,"
+						+ "bastion_type varchar(40) DEFAULT '" + BastionType.getDefaultType() + "',"
+						+ "loc_x int(10),"
+						+ "loc_y int(10),"
+						+ "loc_z int(10),"
+						+ "loc_world varchar(40) NOT NULL,"
+						+ "placed bigint(20) Unsigned,"
+						+ "fraction float(20) Unsigned,"
+						+ "PRIMARY KEY (`bastion_id`));");
+
+		db.registerMigration(1, false,
+				"ALTER TABLE bastion_blocks ADD COLUMN IF NOT EXISTS bastion_type VARCHAR(40) DEFAULT '"
+						+ BastionType.getDefaultType() + "';");
+
+		db.registerMigration(2, false,
+				"ALTER TABLE bastion_blocks ADD COLUMN IF NOT EXISTS dead TINYINT(1) DEFAULT 0;");
+
+		db.registerMigration(3, false,
+				"create table if not exists `bastion_groups`("
+						+ "bastion_group_id int not null,"
+						+ "allowed_group_id int not null,"
+						+ "PRIMARY KEY (bastion_group_id, allowed_group_id));");
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,8 @@ mysql:
   idleTimout: 600000
   maxLifetime: 7200000
   savesPerDay: 64
+commonSettings:
+  cancelReinInBastionField: false
 bastions:
 #The first bastion in this list will be used as the default type
 #This only really matters the first time your start it up when converting from old bastion

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: ${project.name}
 version: ${project.version}
 main: isaac.bastion.Bastion
 author: spaceFountain
-authors: [Rourke750, ProgrammerDan, Maxopoly, TealNerd]
+authors: [Rourke750, ProgrammerDan, Maxopoly, TealNerd, Aleksey-Terzi]
 depend: [CivModCore, Citadel, NameLayer]
 softdepend: [Humbug]
 commands:
@@ -34,6 +34,18 @@ commands:
       description: Insta matures any bastion left clicked 
       usage: /bsm
       permission: Bastion.admin
+   bsga:
+      description: Adds allowed group to bastion group
+      usage: /bsga <bastion group> <allowed group>
+      permission: Bastion.normal
+   bsgd:
+      description: Deletes allowed group from bastion group
+      usage: /bsgd <bastion group> <allowed group>
+      permission: Bastion.normal
+   bsgl:
+      description: List allowed groups in bastion group
+      usage: /bsga <bastion group>
+      permission: Bastion.normal
 permissions:
     Bastion.*:
         description: Gives access to all Bastion commands


### PR DESCRIPTION
**Fixes and tweaks:**

1) Fixed double messaging when player is right clicking in /bsi mode

2) Added new option commonSettings.cancelReinInBastionField
By default it is "false" and everything works as previously.
When it is "true" - then bastion will prevent "/ctr" action if player is not in bastion group and "/ctr" group is not allowed for bastion group

**New functionality:**

Introduced new feature "allowed groups for bastion group"

How it works:

1) Players could add groups to bastion groups

2) When some player haven't permissions on bastion group, but is member of "allowed group of this bastion" then he/she could place blocks using "/ctf allowed_group" or reinforce by using "/ctr allowed_group"even if commonSettings.cancelReinInBastionField = true

3) When such player (who is not in bastion group but in allowed group) is testing bastion field using /bsi - message will tell what group allowed to use

New permissions:

- BASTION_MANAGE_GROUPS - allows to modify "allowed group list"

New commands:

-  bsga:
      description: Adds allowed group to bastion group
      usage: /bsga <bastion group> <allowed group>
      permission: Bastion.normal
-  bsgd:
      description: Deletes allowed group from bastion group
      usage: /bsgd <bastion group> <allowed group>
      permission: Bastion.normal
-  bsgl:
      description: List allowed groups in bastion group
      usage: /bsga <bastion group>
      permission: Bastion.normal