### PR TITLE
Regen patch

### DIFF
--- a/src/main/java/isaac/bastion/BastionBlock.java
+++ b/src/main/java/isaac/bastion/BastionBlock.java
@@ -204,14 +204,17 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
 			if(reinf instanceof PlayerReinforcement) {
 				PlayerReinforcement pr = (PlayerReinforcement) reinf;
 				int maxHealth = ReinforcementType.getReinforcementType(pr.getStackRepresentation()).getHitPoints();
+				health = pr.getDurability();
 				
 				if(maxHealth > health) {
-					reinf.setDurability(health + 1);
-				} else if(balance != 0) {
-					balance = 0;
+					health = Math.min(health + 1, maxHealth);
+					balance = (health == maxHealth ? 0 : balance);
+					reinf.setDurability(health);
 					Bastion.getBastionStorage().updated(this);
 				}
 			} else {
+				health = 0;
+				balance = 0;
 				destroy();
 				Bastion.getPlugin().severe("Reinforcement removed without removing bastion, fixed at " + location);
 			}
@@ -239,7 +242,10 @@ public class BastionBlock implements QTBox, Comparable<BastionBlock> {
 		health -= wholeToRemove;
 		balance = fractionToRemove;
 		
-		if (health <= 0) health = 0;
+		if (health <= 0) {
+			health = 0;
+			balance = 0;
+		}
 
 		reinforcement.setDurability(health);
 


### PR DESCRIPTION
Should address wild behavior when attempting to break regenerative bastions. Basically, health was being improperly tracked, and an old health was being applied during regen, leading to massive health spurts for no apparent reason.

Regeneration was causing massive healing spikes when regenerating during active attack. Discovered that regen basically never worked. This should address it.

Tested, appears to work.