### PR TITLE
Introduced hints for messages and added /bsl command to list bastions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>isaac</groupId>
   <artifactId>Bastion</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.0</version>
+  <version>2.2.1</version>
   <name>Bastion</name>
   <url>https://github.com/DevotedMC/Bastion</url>
   

--- a/src/main/java/isaac/bastion/Bastion.java
+++ b/src/main/java/isaac/bastion/Bastion.java
@@ -2,7 +2,9 @@ package isaac.bastion;
 
 import java.util.LinkedList;
 
+import isaac.bastion.commands.BastionListCommand;
 import isaac.bastion.commands.GroupCommandManager;
+import isaac.bastion.listeners.*;
 import isaac.bastion.manager.BastionGroupManager;
 import isaac.bastion.storage.BastionGroupStorage;
 import isaac.bastion.storage.Database;
@@ -11,10 +13,6 @@ import org.bukkit.configuration.ConfigurationSection;
 import isaac.bastion.commands.BastionCommandManager;
 import isaac.bastion.commands.ModeChangeCommand;
 import isaac.bastion.commands.PlayersStates.Mode;
-import isaac.bastion.listeners.BastionBreakListener;
-import isaac.bastion.listeners.BastionDamageListener;
-import isaac.bastion.listeners.BastionInteractListener;
-import isaac.bastion.listeners.ElytraListener;
 import isaac.bastion.manager.BastionBlockManager;
 import isaac.bastion.storage.BastionBlockStorage;
 import vg.civcraft.mc.civmodcore.ACivMod;
@@ -66,7 +64,8 @@ public final class Bastion extends ACivMod {
 		getServer().getPluginManager().registerEvents(new BastionDamageListener(), this);
 		getServer().getPluginManager().registerEvents(new BastionInteractListener(), this);
 		getServer().getPluginManager().registerEvents(new ElytraListener(), this);
-		getServer().getPluginManager().registerEvents(new BastionBreakListener(blockStorage), this);
+		getServer().getPluginManager().registerEvents(new BastionBreakListener(blockStorage, blockManager), this);
+		getServer().getPluginManager().registerEvents(new NameLayerListener(blockStorage), this);
 	}
 
 	private void setupDatabase() {
@@ -114,6 +113,7 @@ public final class Bastion extends ACivMod {
 		getCommand("bsb").setExecutor(new ModeChangeCommand(Mode.BASTION));
 		getCommand("bsf").setExecutor(new ModeChangeCommand(Mode.OFF));
 		getCommand("bsm").setExecutor(new ModeChangeCommand(Mode.MATURE));
+		getCommand("bsl").setExecutor(new BastionListCommand());
 		getCommand("bsga").setExecutor(new GroupCommandManager(GroupCommandManager.CommandType.Add));
 		getCommand("bsgd").setExecutor(new GroupCommandManager(GroupCommandManager.CommandType.Delete));
 		getCommand("bsgl").setExecutor(new GroupCommandManager(GroupCommandManager.CommandType.List));
@@ -143,15 +143,19 @@ public final class Bastion extends ACivMod {
 		memberAndAbove.add(PlayerType.MODS);
 		memberAndAbove.add(PlayerType.ADMINS);
 		memberAndAbove.add(PlayerType.OWNER);
+
 		LinkedList <PlayerType> modAndAbove = new LinkedList<PlayerType>();
 		modAndAbove.add(PlayerType.MODS);
 		modAndAbove.add(PlayerType.ADMINS);
 		modAndAbove.add(PlayerType.OWNER);
+
 		LinkedList <PlayerType> adminAndAbove = new LinkedList<PlayerType>();
 		adminAndAbove.add(PlayerType.ADMINS);
 		adminAndAbove.add(PlayerType.OWNER);
+
 		PermissionType.registerPermission(Permissions.BASTION_PEARL, memberAndAbove);
 		PermissionType.registerPermission(Permissions.BASTION_PLACE, modAndAbove);
+		PermissionType.registerPermission(Permissions.BASTION_LIST, modAndAbove);
 		PermissionType.registerPermission(Permissions.BASTION_MANAGE_GROUPS, adminAndAbove);
 	}
 

--- a/src/main/java/isaac/bastion/CommonSettings.java
+++ b/src/main/java/isaac/bastion/CommonSettings.java
@@ -8,14 +8,20 @@ import org.bukkit.configuration.ConfigurationSection;
 
 public class CommonSettings {
 	private boolean cancelReinforcementModeInBastionField;
+	private int listBastionTimeout;
 
 	public boolean isCancelReinforcementModeInBastionField() {
 		return this.cancelReinforcementModeInBastionField;
 	}
 
+	public int getListBastionTimeout() {
+		return this.listBastionTimeout;
+	}
+
 	public static CommonSettings load(ConfigurationSection config) {
 		CommonSettings settings = new CommonSettings();
 		settings.cancelReinforcementModeInBastionField = config.getBoolean("cancelReinforcementModeInBastionField", false);
+		settings.listBastionTimeout = config.getInt("listBastionTimeout", 2000);
 
 		return settings;
 	}

--- a/src/main/java/isaac/bastion/Permissions.java
+++ b/src/main/java/isaac/bastion/Permissions.java
@@ -7,5 +7,6 @@ package isaac.bastion;
 public class Permissions {
 	public static final String BASTION_PEARL = "BASTION_PEARL";
 	public static final String BASTION_PLACE = "BASTION_PLACE";
+	public static final String BASTION_LIST = "BASTION_LIST";
 	public static final String BASTION_MANAGE_GROUPS = "BASTION_MANAGE_GROUPS";
 }

--- a/src/main/java/isaac/bastion/commands/BastionListCommand.java
+++ b/src/main/java/isaac/bastion/commands/BastionListCommand.java
@@ -97,6 +97,11 @@ public class BastionListCommand implements CommandExecutor {
 			});
 
 			this.lastExecutions.put(player.getUniqueId(), System.currentTimeMillis());
+		} else {
+			double timeRemained = Bastion.getCommonSettings().getListBastionTimeout() - (System.currentTimeMillis() - lastExecution);
+			String message = ChatColor.RED  + String.format("Slow down, try again in %.1f seconds", (timeRemained / 1000d));
+
+			player.sendMessage(message);
 		}
 
 		return true;

--- a/src/main/java/isaac/bastion/commands/BastionListCommand.java
+++ b/src/main/java/isaac/bastion/commands/BastionListCommand.java
@@ -72,6 +72,8 @@ public class BastionListCommand implements CommandExecutor {
 
 	private static final BastionBlockComparator bastionComparator = new BastionBlockComparator();
 
+	private Map<Player, Long> lastExecutions = new HashMap<>();
+
 	@Override
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
 		if (!(sender instanceof Player)) {
@@ -84,12 +86,18 @@ public class BastionListCommand implements CommandExecutor {
 
 		if(!parseArgs(player, args, argsInfo)) return false;
 
-		Bukkit.getScheduler().runTaskAsynchronously(Bastion.getPlugin(), new Runnable() {
-			@Override
-			public void run() {
-				readListAndShow(player, argsInfo);
-			}
-		});
+		Long lastExecution = this.lastExecutions.get(player);
+
+		if(lastExecution == null || System.currentTimeMillis() - lastExecution > Bastion.getCommonSettings().getListBastionTimeout()) {
+			Bukkit.getScheduler().runTaskAsynchronously(Bastion.getPlugin(), new Runnable() {
+				@Override
+				public void run() {
+					readListAndShow(player, argsInfo);
+				}
+			});
+
+			this.lastExecutions.put(player, System.currentTimeMillis());
+		}
 
 		return true;
 	}

--- a/src/main/java/isaac/bastion/commands/BastionListCommand.java
+++ b/src/main/java/isaac/bastion/commands/BastionListCommand.java
@@ -1,0 +1,294 @@
+/**
+ * Created by Aleksey on 12.08.2017.
+ */
+
+package isaac.bastion.commands;
+
+import com.google.common.base.Strings;
+import isaac.bastion.Bastion;
+import isaac.bastion.BastionBlock;
+import isaac.bastion.Permissions;
+import isaac.bastion.manager.BastionBlockManager;
+import isaac.bastion.utils.ChatFiller;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import vg.civcraft.mc.namelayer.GroupManager;
+import vg.civcraft.mc.namelayer.NameAPI;
+import vg.civcraft.mc.namelayer.group.Group;
+import vg.civcraft.mc.namelayer.permission.PermissionType;
+
+import java.util.*;
+
+public class BastionListCommand implements CommandExecutor {
+	private static class ArgsInfo {
+		public int pageNumber;
+		public List<String> groupNames;
+	}
+
+	private static class GroupInfo {
+		public String name;
+		public List<Integer> ids;
+	}
+
+	private static class BastionInfo {
+		public String location;
+		public String strength;
+		public String group;
+		public String type;
+		public String hoverText;
+	}
+
+	private static class BastionBlockComparator implements Comparator<BastionBlock> {
+		@Override
+		public int compare(BastionBlock b1, BastionBlock b2) {
+			Location l1 = b1.getLocation();
+			Location l2 = b2.getLocation();
+
+			int cmp = l1.getWorld().getName().compareTo(l2.getWorld().getName());
+			if(cmp != 0) return cmp;
+
+			cmp = Integer.compare(l1.getBlockX(), l2.getBlockX());
+			if(cmp != 0) return cmp;
+
+			cmp = Integer.compare(l1.getBlockZ(), l2.getBlockZ());
+			if(cmp != 0) return cmp;
+
+			return Integer.compare(l1.getBlockY(), l2.getBlockY());
+		}
+	}
+
+	private static final int pageSize = 10;
+	private static final double locationColWidth = 26;
+	private static final double groupColWidth = 22;
+	private static final double typeColWidth = 10;
+
+	private static final BastionBlockComparator bastionComparator = new BastionBlockComparator();
+
+	@Override
+	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+		if (!(sender instanceof Player)) {
+			sender.sendMessage(ChatColor.RED + "Only player could use this command.");
+			return false;
+		}
+
+		final Player player = (Player)sender;
+		final ArgsInfo argsInfo = new ArgsInfo();
+
+		if(!parseArgs(player, args, argsInfo)) return false;
+
+		Bukkit.getScheduler().runTaskAsynchronously(Bastion.getPlugin(), new Runnable() {
+			@Override
+			public void run() {
+				readListAndShow(player, argsInfo);
+			}
+		});
+
+		return true;
+	}
+
+	private static boolean parseArgs(Player player, String[] args, ArgsInfo result) {
+		result.pageNumber = 1;
+		result.groupNames = null;
+
+		if (args.length == 0) return true;
+
+		// Reassemble any arguments that are enclosed in quotes and were split
+		List<String> fixedArgs = new ArrayList<String>();
+		Scanner scanner = new Scanner(String.join(" ", args));
+		scanner.useDelimiter("\\s(?=([^\"]*\"[^\"]*\")*[^\"]*$)");
+		while (scanner.hasNext()) {
+			fixedArgs.add(scanner.next());
+		}
+		scanner.close();
+
+		// Parse each argument
+		for (String arg : fixedArgs) {
+			arg = arg.toLowerCase().trim();
+			if (arg.startsWith("groups=")) {
+				if (arg.length() > 7) {
+					String groupNamesRaw = arg.substring(7);
+					// Strip quotes
+					groupNamesRaw = groupNamesRaw.replaceAll("^[\"']|[\"']$", "");
+					result.groupNames = Arrays.asList(groupNamesRaw.split(","));
+					continue;
+				}
+			} else {
+				try {
+					result.pageNumber = Integer.parseInt(arg);
+				} catch (NumberFormatException e) {
+					result.pageNumber = 1;
+				}
+				continue;
+			}
+
+			player.sendMessage(ChatColor.RED + "Unrecognized argument: '" + arg + "'");
+			return false;
+		}
+
+		return true;
+	}
+
+	private static void readListAndShow(Player player, ArgsInfo argsInfo) {
+		List<BastionInfo> list = readList(player.getUniqueId(), argsInfo);
+
+		if(list.size() == 0) {
+			Bukkit.getScheduler().runTask(Bastion.getPlugin(), new Runnable() {
+				@Override
+				public void run() {
+					player.sendMessage(ChatColor.AQUA + " * Page " + argsInfo.pageNumber + " is empty");
+				}
+			});
+			return;
+		}
+
+		showList(player, argsInfo, list);
+	}
+
+	private static void showList(final Player player, ArgsInfo argsInfo, List<BastionInfo> list) {
+		String topLine = ChatColor.WHITE + " Bastion List " + ChatColor.DARK_GRAY + Strings.repeat("-", 10) + "\n";
+
+		String columnNames = ChatColor.GRAY
+				+ ChatFiller.fillString("Location", locationColWidth)
+				+ ChatFiller.fillString("Group", groupColWidth)
+				+ ChatFiller.fillString("Type", typeColWidth)
+				+ "\n"
+				+ ChatColor.WHITE;
+
+		final TextComponent output = new TextComponent(topLine);
+		output.addExtra(columnNames);
+
+		Map<String, String> shortenings = new HashMap<>();
+
+		for(BastionInfo info : list) {
+			TextComponent line = new TextComponent(ChatFiller.fillString(info.location, locationColWidth));
+			line.addExtra(ChatFiller.fillString(info.group, groupColWidth));
+			line.addExtra(ChatFiller.fillString(getBastionType(info.type, shortenings), typeColWidth));
+			line.addExtra("\n");
+
+			line.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(info.hoverText).create()));
+
+			output.addExtra(line);
+		}
+
+		if(shortenings.size() > 0) {
+			List<String> shortNames = new ArrayList<>();
+			shortNames.addAll(shortenings.keySet());
+			Collections.sort(shortNames);
+
+			for(String shortName : shortNames) {
+				String comment = ChatColor.GRAY + "* " + shortName + " = " + shortenings.get(shortName) + "\n";
+				output.addExtra(comment);
+			}
+		}
+
+		String bottomLine = ChatColor.DARK_GRAY + " * Page " + argsInfo.pageNumber + " ";
+		bottomLine = bottomLine + Strings.repeat("-", bottomLine.length());
+		output.addExtra(bottomLine);
+
+		Bukkit.getScheduler().runTask(Bastion.getPlugin(), new Runnable() {
+			@Override
+			public void run() {
+				player.spigot().sendMessage(output);
+			}
+		});
+	}
+
+	private static String getBastionType(String type, Map<String, String> shortenings) {
+		if(type.length() < typeColWidth) return type;
+
+		String[] parts = type.split(" ");
+		StringBuilder result = new StringBuilder();
+
+		for(String part : parts) {
+			result.append(part.substring(0, 1).toUpperCase());
+		}
+
+		String shortName = result.toString();
+
+		if(!shortenings.containsKey(shortName)) {
+			shortenings.put(shortName, type);
+		}
+
+		return shortName;
+	}
+
+	private static List<BastionInfo> readList(UUID playerId, ArgsInfo argsInfo) {
+		BastionBlockManager manager = Bastion.getBastionManager();
+		List<GroupInfo> groups = getPlayerGroups(playerId, argsInfo.groupNames);
+		List<BastionInfo> result = new ArrayList<>();
+		List<BastionBlock> buffer = new ArrayList<>();
+		int start = (argsInfo.pageNumber - 1) * pageSize;
+		int end = start + pageSize - 1;
+		int current = 0;
+
+		for(GroupInfo groupInfo : groups) {
+			if(current > end) break;
+
+			manager.getBastionsByGroupIds(groupInfo.ids, buffer);
+
+			Collections.sort(buffer, bastionComparator);
+
+			for(BastionBlock bastion : buffer) {
+				if(current >= start) {
+					BastionInfo bastionInfo = new BastionInfo();
+					bastionInfo.location = bastion.getLocationText();
+					bastionInfo.strength = bastion.getStrengthText();
+					bastionInfo.group = groupInfo.name;
+					bastionInfo.type = bastion.getType().getItemName();
+					bastionInfo.hoverText = bastion.getHoverText();
+
+					result.add(bastionInfo);
+				}
+
+				current++;
+
+				if(current > end) break;
+			}
+
+			buffer.clear();
+		}
+
+		return result;
+	}
+
+	private static List<GroupInfo> getPlayerGroups(UUID playerId, List<String> groupNames) {
+		PermissionType permission = PermissionType.getPermission(Permissions.BASTION_LIST);
+		GroupManager groupManager = NameAPI.getGroupManager();
+		List<GroupInfo> result = new ArrayList<GroupInfo>();
+
+		if(groupNames == null) {
+			groupNames = groupManager.getAllGroupNames(playerId);
+		}
+
+		Collections.sort(groupNames);
+
+		Set<String> processedGroupNames = new HashSet<>();
+
+		for (String groupName : groupNames) {
+			if(processedGroupNames.contains(groupName.toLowerCase())) continue;
+
+			processedGroupNames.add(groupName.toLowerCase());
+
+			Group group = GroupManager.getGroup(groupName);
+
+			if (group != null && groupManager.hasAccess(group, playerId, permission)) {
+				GroupInfo info = new GroupInfo();
+				info.name = group.getName();
+				info.ids = group.getGroupIds();
+
+				result.add(info);
+			}
+		}
+
+		return result;
+	}
+
+}

--- a/src/main/java/isaac/bastion/commands/BastionListCommand.java
+++ b/src/main/java/isaac/bastion/commands/BastionListCommand.java
@@ -72,7 +72,7 @@ public class BastionListCommand implements CommandExecutor {
 
 	private static final BastionBlockComparator bastionComparator = new BastionBlockComparator();
 
-	private Map<Player, Long> lastExecutions = new HashMap<>();
+	private Map<UUID, Long> lastExecutions = new HashMap<>();
 
 	@Override
 	public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
@@ -86,7 +86,7 @@ public class BastionListCommand implements CommandExecutor {
 
 		if(!parseArgs(player, args, argsInfo)) return false;
 
-		Long lastExecution = this.lastExecutions.get(player);
+		Long lastExecution = this.lastExecutions.get(player.getUniqueId());
 
 		if(lastExecution == null || System.currentTimeMillis() - lastExecution > Bastion.getCommonSettings().getListBastionTimeout()) {
 			Bukkit.getScheduler().runTaskAsynchronously(Bastion.getPlugin(), new Runnable() {
@@ -96,7 +96,7 @@ public class BastionListCommand implements CommandExecutor {
 				}
 			});
 
-			this.lastExecutions.put(player, System.currentTimeMillis());
+			this.lastExecutions.put(player.getUniqueId(), System.currentTimeMillis());
 		}
 
 		return true;

--- a/src/main/java/isaac/bastion/listeners/NameLayerListener.java
+++ b/src/main/java/isaac/bastion/listeners/NameLayerListener.java
@@ -1,0 +1,37 @@
+/**
+ * Created by Aleksey on 15.08.2017.
+ */
+
+package isaac.bastion.listeners;
+
+import isaac.bastion.storage.BastionBlockStorage;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import vg.civcraft.mc.namelayer.events.GroupDeleteEvent;
+import vg.civcraft.mc.namelayer.events.GroupMergeEvent;
+
+import java.util.List;
+
+public class NameLayerListener implements Listener {
+	private BastionBlockStorage storage;
+
+	public NameLayerListener(BastionBlockStorage storage) {
+		this.storage = storage;
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onGroupMergeEvent(GroupMergeEvent event) {
+		int toGroupId = event.getMergingInto().getGroupId();
+		List<Integer> fromGroupIds = event.getToBeMerged().getGroupIds();
+
+		this.storage.mergeGroups(toGroupId, fromGroupIds);
+	}
+
+	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+	public void onGroupDeleteEvent(GroupDeleteEvent event) {
+		List<Integer> groupIds = event.getGroup().getGroupIds();
+
+		this.storage.removeGroups(groupIds);
+	}
+}

--- a/src/main/java/isaac/bastion/utils/ChatFiller.java
+++ b/src/main/java/isaac/bastion/utils/ChatFiller.java
@@ -1,0 +1,257 @@
+/**
+ * Created by Aleksey on 13.08.2017.
+ */
+// Adapted from https://github.com/andfRa/Saga
+
+package isaac.bastion.utils;
+
+import org.bukkit.ChatColor;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ChatFiller {
+	/**
+	 * Default character length.
+	 */
+	public final static Double DEFAULT_LENGTH = 3.0 / 2.0;
+
+	/**
+	 * Maximum character length.
+	 */
+	public final static Double MAX_LENGTH = 3.0 / 2.0;
+
+	/**
+	 * Gap fill string maximum size.
+	 */
+	private final static Double MAX_GAP = 1.25;
+
+	/**
+	 * Chat width.
+	 */
+	public final static Double CHAT_WIDTH = 80.0;
+
+	/**
+	 * Size map.
+	 */
+	private final static HashMap<Character, Double> SIZE_MAP = new HashMap<Character, Double>() {
+
+		/**
+		 * Serial version UID.
+		 */
+		private static final long serialVersionUID = 1L;
+
+		{
+			put('i', 0.5);
+			put('k', 5.0 / 4.0);
+			put('t', 1.0);
+			put('f', 5.0 / 4.0);
+			put('(', 5.0 / 4.0);
+			put(')', 5.0 / 4.0);
+			put('<', 5.0 / 4.0);
+			put('>', 5.0 / 4.0);
+			put('{', 5.0 / 4.0);
+			put('}', 5.0 / 4.0);
+			put(',', 1.0 / 2.0);
+			put('.', 1.0 / 2.0);
+			put('[', 1.0);
+			put(']', 1.0);
+			put('I', 1.0);
+			put('|', 1.0 / 2.0);
+			put('*', 5.0 / 4.0);
+			put('"', 5.0 / 4.0);
+			put('|', 0.5);
+			put('!', 0.5);
+			put(':', 0.5);
+			put('l', 3.0 / 4.0);
+			put('.', 1.0 / 2.0);
+			put('\'', 3.0 / 4.0);
+			put(' ', 1.0 / 1.0);
+			put('\"', 5.0 / 4.0);
+			put('`', 0.5);
+			put('\0', 0.0);
+
+			put(' ', 1.0);
+
+			put('\u2500', 5.0 / 4.0);
+			put('\u2502', 1.0 / 4.0);
+			put('\u250C', 3.0 / 4.0);
+			put('\u2510', 3.0 / 4.0);
+			put('\u2514', 3.0 / 4.0);
+			put('\u2518', 3.0 / 4.0);
+
+			put('\u2550', 5.0 / 4.0);
+			put('\u2551', 1.0 / 2.0);
+
+			put('\u2554', 3.0 / 4.0);
+			put('\u2560', 3.0 / 4.0);
+			put('\u255A', 3.0 / 4.0);
+
+			put('\u2557', 4.0 / 4.0);
+			put('\u2563', 4.0 / 4.0);
+			put('\u255D', 4.0 / 4.0);
+
+			put('\u2591', 2.0);
+		}
+	};
+
+	/**
+	 * Gap fill chars.
+	 */
+	private final static HashSet<Character> FILL_CHARS = new HashSet<Character>() {
+
+		private static final long serialVersionUID = 1L;
+		{
+			add(' ');
+		}
+	};
+
+	/**
+	 * Trims and/or fills a string to be as close to the required length without exceeding it.
+	 * If the string is trimmed, the supplied suffix is added (provided that won't exceed reqLength)
+	 * @param str string to trim/fill
+	 * @param reqLength required length
+	 * @return the trimmed/filled string
+	 */
+	public static String fillString(String str, Double reqLength, String suffix) {
+
+		double suffixLength = calcLength(suffix);
+		char[] chars = str.toCharArray();
+		StringBuffer result = new StringBuffer();
+		StringBuffer suffixResult = new StringBuffer();
+		Double length = 0.0;
+
+		// Cut size and add suffix if necessary
+		boolean suffixFilled = false;
+		for (int i = 0; i < chars.length; i++) {
+			Double charLength = SIZE_MAP.get(chars[i]);
+			if (charLength == null) {
+				charLength = DEFAULT_LENGTH;
+			}
+
+			if (!suffixFilled && length + charLength + suffixLength > reqLength) {
+				suffixFilled = true;
+				suffixResult.append(suffix);
+			}
+
+			if (length + charLength > reqLength) {
+				result = suffixResult;
+				break;
+			}
+
+			result.append(chars[i]);
+			if (!suffixFilled) {
+				suffixResult.append(chars[i]);
+			}
+
+			if (!(chars[i] == ChatColor.COLOR_CHAR || (i > 0 && chars[i - 1] == ChatColor.COLOR_CHAR))) {
+				length += charLength;
+			}
+		}
+
+		// Add spaces:
+		Character fillChar = ' ';
+		Double fillLength = 1.0;
+		while (true) {
+			Double gapLength = reqLength - length;
+
+			// Gap filled:
+			if (gapLength <= 0) {
+				break;
+			}
+
+			// Add custom fillers:
+			if (gapLength <= MAX_GAP) {
+
+				fillChar = findCustom(gapLength, reqLength);
+				if (fillChar != null) {
+					result.append(fillChar);
+					fillLength = SIZE_MAP.get(fillChar);
+				}
+				break;
+			}
+			result.append(fillChar);
+			length += fillLength;
+		}
+		return result.toString();
+	}
+
+	/**
+	 * Trims and/or fills a string to be as close to the required length without exceeding it.
+	 * If the string is trimmed, no suffix is added
+	 * @param str string to trim/fill
+	 * @param reqLength required length
+	 * @return the trimmed/filled string <= required length
+	 */
+	public static String fillString(String str, Double reqLength) {
+
+		return fillString(str, reqLength, "");
+	}
+
+	/**
+	 * Finds a custom character with the best fit.
+	 *
+	 * @param gapLen gap length
+	 * @param reqLength required length
+	 * @return char that best fits the gap, null if none
+	 */
+	private static Character findCustom(Double gapLen, Double reqLength) {
+
+		Set<Character> gapStrs = new HashSet<Character>(FILL_CHARS);
+		Double bestFitLen = -1.0;
+		Character bestFitStr = null;
+
+		for (Character gapStr : gapStrs) {
+
+			Double gapStrLen = SIZE_MAP.get(gapStr);
+
+			if (gapLen - gapStrLen >= 0 && gapStrLen > bestFitLen) {
+				bestFitLen = gapStrLen;
+				bestFitStr = gapStr;
+			}
+		}
+		return bestFitStr;
+	}
+
+	/**
+	 * Calculates the length of a string.
+	 *
+	 * @param str string
+	 * @return string length
+	 */
+	public static Double calcLength(String str) {
+
+		char[] chars = str.toCharArray();
+
+		Double length = 0.0;
+
+		for (int i = 0; i < chars.length; i++) {
+			Double charLength = SIZE_MAP.get(chars[i]);
+			if (charLength == null) {
+				charLength = DEFAULT_LENGTH;
+			}
+
+			if (!(chars[i] == ChatColor.COLOR_CHAR || (i > 0 && chars[i - 1] == ChatColor.COLOR_CHAR))) {
+				length += charLength;
+			}
+		}
+		return length;
+	}
+
+	/**
+	 * Adjusts filler characters.
+	 *
+	 * @param str string
+	 * @return adjusted string
+	 */
+	public static String adjustFillers(String str) {
+
+		str = str.replace("\u278A", ChatColor.DARK_GRAY + "`");
+
+		str = str.replace("\u278B", ChatColor.DARK_GRAY + "" + ChatColor.BOLD + "`");
+		str = str.replace("\u278C", ChatColor.DARK_GRAY + "" + ChatColor.BOLD + " ");
+
+		return str;
+	}
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,7 +10,8 @@ mysql:
   maxLifetime: 7200000
   savesPerDay: 64
 commonSettings:
-  cancelReinInBastionField: false
+  cancelReinforcementModeInBastionField: false
+  listBastionTimeout: 2000
 bastions:
 #The first bastion in this list will be used as the default type
 #This only really matters the first time your start it up when converting from old bastion

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -34,6 +34,9 @@ commands:
       description: Insta matures any bastion left clicked 
       usage: /bsm
       permission: Bastion.admin
+   bsl:
+    description: Displays list of bastions
+    usage: /bsl <page number> [groups=<group1>,<group2>,...]
    bsga:
       description: Adds allowed group to bastion group
       usage: /bsga <bastion group> <allowed group>


### PR DESCRIPTION
1) Upgrade has purpose to introduce features required for BastionMaster mod

2) Introduced new permission BASTION_LIST, which allows to display list of bastions and see detailed information about bastions in the hint

3) When user is right clicking bastion block in /bsi mode - message was changed to "Bastion: 'strength description'" instead of "'strength description'". Also if player has BASTION_LIST perm - will be shown additional information in the hint

4) Message "Bastion block created" now has hint with detailed information

5) When player is breaking bastion block and has BASTION_LIST perm for bastion group - will be shown message "Bastion deleted" with additional information in the hint

6) Introduced command **/bsl** which allows to list all player's bastions, i.e. bastions in groups where player has BASTION_LIST perm. Each row in the list has additional information in the hint

Example of result of /bsl command:

![image](https://user-images.githubusercontent.com/5383652/29319519-f9a254ae-81dc-11e7-9e80-ebe3e8019f95.png)

Example of additional information in hint:

![image](https://user-images.githubusercontent.com/5383652/29319576-2561e8c0-81dd-11e7-94e4-82057da8d0e5.png)

